### PR TITLE
group recent entries by location

### DIFF
--- a/templates/homepage-template.php
+++ b/templates/homepage-template.php
@@ -57,7 +57,7 @@ infinity_get_header();
             </div>
             <div id="tabs-2">
 				<?php
-				$events_recent = '[events_list orderby="event_date_created" order="DESC" limit="4"]';
+				$events_recent = '[events_list orderby="event_name" groupby="location_id" groupby_orderby="event_date_created" groupby_order="DESC"]';
 				echo do_shortcode( $events_recent );
 				?>
             </div>


### PR DESCRIPTION
with events manager 5.8+ comes the ability to group events, making this very straight forward. 

ref: http://wp-events-plugin.com/documentation/event-search-attributes/event-location-grouping-ordering/

addresses https://github.com/BCcampus/eypd/issues/245