### PR TITLE
trigger eypd runonce to update search label text

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -357,7 +357,7 @@ function eypd_get_provinces() {
 function eypd_run_once() {
 
 	// change eypd_version value to run it again
-	$eypd_version        = 6.4;
+	$eypd_version        = 6.5;
 	$current_version     = get_option( 'eypd_version', 0 );
 	$img_max_dimension   = 1000;
 	$img_min_dimension   = 50;


### PR DESCRIPTION
Search label text wasn't updated in cert, increasing version to make it apply new search label text in `eypd_run_once()`