### PR TITLE
Make headings fit better on small screens

### DIFF
--- a/assets/styles/common/_global.scss
+++ b/assets/styles/common/_global.scss
@@ -37,10 +37,18 @@ h1, h2, h3, h4, h5, h6, p, label, span.label {
 
 h1 {
   font-size: 48px;
+
+  @media (max-width: $medium) {
+    font-size: 32px;
+  }
 }
 
 h2 {
   font-size: 32px;
+
+  @media (max-width: $medium) {
+    font-size: 26px;
+  }
 }
 
 h3 {


### PR DESCRIPTION
Solves #533

<img width="376" alt="screen shot 2018-09-26 at 10 31 04 pm" src="https://user-images.githubusercontent.com/20425828/46125135-9e716e80-c1dc-11e8-9952-cad647aa6876.png">
