### PR TITLE
headings are meant for pages, remove from bbpress tinymce

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1785,6 +1785,19 @@ add_filter( 'excel_export_user_buddypress', function ( $default_user_buddypress 
 	return array_merge( $default_user_buddypress, $add_buddypress );
 } );
 
+/**
+ * Enable the visual editor on bbpress
+ */
+add_filter( 'bbp_after_get_the_content_parse_args', function ( $args = [] ) {
+	$args['tinymce'] = true;
+	$args['teeny']   = false;
+	$args['tinymce'] = [
+		'toolbar1' => 'bold, italic, blockquote, strikethrough, bulletedlist, numberedlist, alignleft, aligncenter, alignright, undo, redo, link, image',
+	];
+
+	return $args;
+} );
+
 /*
 |--------------------------------------------------------------------------
 | Layout Overrides


### PR DESCRIPTION
The headings select list was showing up in tinyMCE, which was not actually an allowed tag in a reply. Removing this will fix any confusion for what formatting is allowed when replying a forum topic. 